### PR TITLE
[FE]feat: accessToken 메모리화, 갱신 기능

### DIFF
--- a/client/src/apis/EduApi.ts
+++ b/client/src/apis/EduApi.ts
@@ -1,0 +1,7 @@
+import axios, { AxiosInstance } from "axios";
+
+const eduApi: AxiosInstance = axios.create({
+  baseURL: `${import.meta.env.VITE_APP_API_URL}`,
+});
+
+export default eduApi;

--- a/client/src/apis/TokenRequestApi.ts
+++ b/client/src/apis/TokenRequestApi.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosInstance } from "axios";
+import eduApi from "./EduApi";
+import { getRefreshToken } from "../pages/utils/Auth";
+
+let accessToken: string | null = null;
+const tokenRequestApi: AxiosInstance = axios.create({
+  baseURL: `${import.meta.env.VITE_APP_API_URL}`,
+});
+
+tokenRequestApi.interceptors.request.use(
+  (config) => {
+    config.headers = config.headers || {};
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+const extendAccessToken = async () => {
+  const expirationTime = 60 * 1000; // 1분
+  const timeToExpire =
+    new Date(Number(new Date()) + expirationTime).getTime() -
+    new Date().getTime();
+
+  // 1분 미만일 때 자동으로 accessToken을 갱신
+  setTimeout(async () => {
+    const refreshToken = getRefreshToken();
+
+    try {
+      const response = await eduApi.post(`/refresh`, null, {
+        headers: {
+          Refresh: `${refreshToken}`,
+        },
+      });
+
+      const { accessToken: newAccessToken } = response.data;
+      tokenRequestApi.setAccessToken(newAccessToken);
+
+      console.log("accessToken 갱신됨");
+    } catch (error) {
+      console.error("accessToken 갱신 실패:", error);
+    }
+  }, timeToExpire);
+};
+
+tokenRequestApi.setAccessToken = (token): void => {
+  accessToken = token;
+  extendAccessToken();
+};
+
+export default tokenRequestApi;

--- a/client/src/components/gnb/GNB.tsx
+++ b/client/src/components/gnb/GNB.tsx
@@ -1,14 +1,12 @@
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
-import axios from "axios";
 import styled from "styled-components";
 import logo from "../../assets/edusync-logo.png";
 import User from "./User";
-import { getAccessToken } from "../../pages/utils/Auth";
+import tokenRequestApi from "../../apis/TokenRequestApi";
 import { useRecoilState } from "recoil";
 import { LogInState } from "../../recoil/atoms/LogInState";
 
-const accessToken = getAccessToken();
 const GNB = () => {
   const [profileImage, setProfileImage] = useState("");
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(LogInState);
@@ -17,15 +15,14 @@ const GNB = () => {
   useEffect(() => {
     if (isLoggedIn) {
       setIsLoading(true);
-      axios
-        .get(`${import.meta.env.VITE_APP_API_URL}/members`, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        })
+      tokenRequestApi
+        .get("/members")
         .then((res) => {
           setProfileImage(res.data.profileImage);
           setIsLoading(false);
+        })
+        .catch((err) => {
+          console.log(err);
         });
     }
   }, [isLoggedIn]);
@@ -33,7 +30,19 @@ const GNB = () => {
   return (
     <>
       {isLoading ? (
-        <GNBDiv></GNBDiv>
+        <GNBDiv>
+          <GNBBlock>
+            <HomeLink to="/">
+              <img src={logo} />
+            </HomeLink>
+          </GNBBlock>
+
+          <User
+            profileImage={profileImage}
+            isLoggedIn={isLoggedIn}
+            setIsLoggedIn={setIsLoggedIn}
+          />
+        </GNBDiv>
       ) : (
         <GNBDiv>
           <GNBBlock>

--- a/client/src/components/gnb/User.tsx
+++ b/client/src/components/gnb/User.tsx
@@ -1,9 +1,7 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import tokenRequestApi from "../../apis/TokenRequestApi";
 import { useNavigate } from "react-router-dom";
-//import { useRecoilValue } from "recoil";
-//import { isLoggedInSelector } from "../../recoil/selectors/IsLoggedInSelector";
-//import { googleLogout } from "@react-oauth/google";
 import { removeTokens } from "../../pages/utils/Auth";
 
 type GNB = {
@@ -16,6 +14,7 @@ const User = ({ profileImage, isLoggedIn, setIsLoggedIn }: GNB) => {
   const navigate = useNavigate();
 
   const handleLogout = (): void => {
+    tokenRequestApi.setAccessToken(null);
     removeTokens();
     setIsLoggedIn(false);
     navigate("/");

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,11 +4,12 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate, Link } from "react-router-dom";
 import axios from "axios";
 import logo from "../assets/edusync-logo.png";
+import tokenRequestApi from "../apis/TokenRequestApi";
 import { validateEmptyInput } from "./utils/loginUtils";
-import { setAccessToken, setRefreshToken } from "./utils/Auth";
 import { useSetRecoilState } from "recoil";
 import { LogInState } from "../recoil/atoms/LogInState";
 import Google from "../components/GoogleLogin";
+import { setRefreshToken } from "./utils/Auth";
 
 const Login = () => {
   const [email, setEmail] = useState("");
@@ -27,7 +28,7 @@ const Login = () => {
 
   const loginMutation = useMutation(
     () =>
-      axios.post(`${import.meta.env.VITE_APP_API_URL}/members/login`, {
+      tokenRequestApi.post("/members/login", {
         email,
         password,
       }),
@@ -35,7 +36,7 @@ const Login = () => {
       onSuccess: (data) => {
         const accessToken = data.headers.authorization;
         const refreshToken = data.headers.refresh;
-        setAccessToken(accessToken);
+        tokenRequestApi.setAccessToken(accessToken);
         setRefreshToken(refreshToken);
         setIsLoggedIn(true);
         navigate("/");


### PR DESCRIPTION
- google 로그인 (배포 버전에서만 확인 가능해 아직 확인 불가)
- eduApi(일반적인 api 요청시 사용)
- tokenRequestApi(헤더에 accessToken이 담긴 요청이 필요할 경우 -> 따로 헤더에 담아서 보내지 않아도 자동화되도록 구현)
- extendAccessToken 함수 -> refreshToken으로 만료시간 1분전에 토큰 재발급
- 
생각해봐야할 점
- refresh 토큰은 로컬 스토리지에 그대로 있고 access 토큰만 메모리로 옮기는 게 맞는지
- 새로고침하면 accessToken이 없어지는 문제는 어떻게 해결 할지
- TokenRequestApi.ts 안에 해당 내용을 다 넣는 게 맞는지, 분리한다면 어떤 폴더에 만들어야 할지