### PR TITLE
commnet: RedisConfig 설명 추가

### DIFF
--- a/server/edusync/src/main/java/com/codestates/edusync/config/redis/RedisConfig.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/config/redis/RedisConfig.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
-public class RedisConfig {
+public class RedisConfig { // Redis Template을 사용하기 위한 클래스 (확장성을 고려해 추가. 지금은 사실상 안쓰이는 코드)
 
     private final String redisHost;
     private final int redisPort;

--- a/server/edusync/src/main/java/com/codestates/edusync/model/member/entity/Member.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/member/entity/Member.java
@@ -29,7 +29,7 @@ public class Member extends Auditable {
     private String uuid = UUID.randomUUID().toString();
     @Column(nullable = false, updatable = true, unique = true)
     private String nickName;
-    @Column(nullable = false, updatable = false, unique = true)
+    @Column(nullable = false, updatable = true, unique = true)
     private String email;
     @Column(length = 2147483647)    // fixme : 길이 제한 걸릴 경우 length = -1 이나 columnDefinition = "TEXT" 타입 고려
     private String profileImage;


### PR DESCRIPTION
RedisConfig 클래스는 지금 사실상 안쓰이는 코드이긴 합니다.

Redis를 사용하는 2가지 방법 중 Repository 방식을 택했기 때문이고 Redis Template 방식을 선택하려면 RedisConfig가 필요합니다.
후에 방식을 바꾸게 될 가능성을 생각해 미리 만들어 뒀다고 생각해주시면 될 것 같습니다.

Repository방식은 해시형만 저장 가능하기 때문에 후에 redis에 다른 형태의 데이터를 저장하려면 Redis Template 방식으로 바꿔야하기 떄문입니다!