### PR TITLE
remove: tmi 코드설명 주석 제거

### DIFF
--- a/server/edusync/src/main/java/com/codestates/edusync/config/SecurityConfiguration.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/config/SecurityConfiguration.java
@@ -29,8 +29,8 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableWebSecurity // Spring Security를 사용하기 위한 필수 설정들을 자동으로 등록
-@EnableGlobalMethodSecurity(prePostEnabled = true) // 메소드 보안 기능 활성화
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfiguration {
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
@@ -40,65 +40,63 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()        // CSRF공격에 대한 Spring Security에 대한 설정을 비활성화
-                .cors(withDefaults())    // CORS 설정 추가 (corsConfigurationSource라는 이름으로 등록된 Bean을 이용)
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)  // 세션을 생성하지 않도록 설정
+                .csrf().disable()
+                .cors(withDefaults())
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .formLogin().disable()   // 폼 로그인 방식을 비활성화
-                .httpBasic().disable()   // HTTP Basic 인증 방식을 비활성화
+                .formLogin().disable()
+                .httpBasic().disable()
                 .exceptionHandling()
-                .authenticationEntryPoint(new MemberAuthenticationEntryPoint())  // 인증오류가 발생할 때 처리해주는 핸들러 호출
-                .accessDeniedHandler(new MemberAccessDeniedHandler())  // 인증에는 성공했지만 해당 리소스에 대한 권한이 없을 때 처리해주는 핸들러 호출
+                .authenticationEntryPoint(new MemberAuthenticationEntryPoint())
+                .accessDeniedHandler(new MemberAccessDeniedHandler())
                 .and()
-                .apply(new CustomFilterConfigurer())   // Custom Configurer 적용
+                .apply(new CustomFilterConfigurer())
                 .and()
                 .authorizeHttpRequests(authorize -> authorize
-                                .anyRequest().permitAll()                // 모든 HTTP request 요청에 대해서 접근 허용
+                                .anyRequest().permitAll()
                 )
                 .oauth2Login()
-                .successHandler(oAuth2MemberSuccessHandler);  // OAuth 2 인증이 성공한 뒤 실행되는 핸들러를 추가
-//                .userInfoEndpoint() // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때 설정을 저장
-//                .userService(oauth2Service); // OAuth2 로그인 성공 시, 후작업을 진행할 UserService 인터페이스 구현체 등록
+                .successHandler(oAuth2MemberSuccessHandler);
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder(); // PasswordEncoder Bean 객체 생성
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
 
     // CORS 정책 설정하는 방법
     @Bean
-    CorsConfigurationSource corsConfigurationSource() { // CorsConfigurationSource Bean 생성을 통해 구체적인 CORS 정책을 설정
+    CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("GET","POST", "PATCH", "DELETE", "OPTIONS"));  // 파라미터로 지정한 HTTP Method에 대한 HTTP 통신을 허용
+        configuration.setAllowedMethods(Arrays.asList("GET","POST", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setExposedHeaders(Arrays.asList("*"));
         configuration.addAllowedHeader("*");
-        configuration.setAllowCredentials(Boolean.valueOf(true)); // 토큰인증방식 이용할거니까 프론트측에서 Credentials true 가능하게 허용
+        configuration.setAllowCredentials(Boolean.valueOf(true));
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();   // CorsConfigurationSource 인터페이스의 구현 클래스인 UrlBasedCorsConfigurationSource 클래스의 객체를 생성
-        source.registerCorsConfiguration("/**", configuration);      // 모든 URL에 앞에서 구성한 CORS 정책(CorsConfiguration)을 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 
     // Custom Configurer 클래스 (JwtAuthenticationFilter를 등록하는 역할)
-    public class CustomFilterConfigurer extends AbstractHttpConfigurer<CustomFilterConfigurer, HttpSecurity> {  // AbstractHttpConfigurer를 상속해서 Custom Configurer를 구현할 수 있다.
+    public class CustomFilterConfigurer extends AbstractHttpConfigurer<CustomFilterConfigurer, HttpSecurity> {
         @Override
-        public void configure(HttpSecurity builder) throws Exception {  // configure() 메서드를 오버라이드해서 Configuration을 커스터마이징
-            AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);  // AuthenticationManager 객체 가져오기
+        public void configure(HttpSecurity builder) throws Exception {
+            AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 
-            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtTokenizer, tokenService);  // JwtAuthenticationFilter를 생성하면서 JwtAuthenticationFilter에서 사용되는 AuthenticationManager와 JwtTokenizer를 DI
-            jwtAuthenticationFilter.setFilterProcessesUrl("/members/login"); // setFilterProcessesUrl() 메서드를 통해 디폴트 request URL인 “/login”을 “/members/login”으로 변경
-            jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler());  // 인증 성공시 사용할 객체 등록
-            jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());  // 인증 실패시 사용할 객체 등록
+            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, tokenService);
+            jwtAuthenticationFilter.setFilterProcessesUrl("/members/login");
+            jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler());
+            jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());
 
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils);  // JwtVerificationFilter의 인스턴스를 생성하면서 JwtVerificationFilter에서 사용되는 객체들을 생성자로 DI
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils);
 
-            builder.addFilter(jwtAuthenticationFilter)  // addFilter() 메서드를 통해 JwtAuthenticationFilter를 Spring Security Filter Chain에 추가
-                    .addFilterAfter(jwtVerificationFilter, JwtAuthenticationFilter.class)   // JwtVerificationFilter는 JwtAuthenticationFilter에서 로그인 인증에 성공한 후 발급 받은 JWT가 클라이언트의 request header(Authorization 헤더)에 포함되어 있을 경우에만 동작한다.
+            builder.addFilter(jwtAuthenticationFilter)
+                    .addFilterAfter(jwtVerificationFilter, JwtAuthenticationFilter.class)
                     .addFilterAfter(jwtVerificationFilter, OAuth2LoginAuthenticationFilter.class);
         }
     }

--- a/server/edusync/src/main/java/com/codestates/edusync/filter/JwtAuthenticationFilter.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/filter/JwtAuthenticationFilter.java
@@ -20,30 +20,26 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-// 로그인 인증 요청을 처리하는 Custom Security Filter 구현
-public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {  // 디폴트 Security Filter인 UsernamePasswordAuthenticationFilter를 확장해서 구현
+// 로그인 인증 요청을 처리하는 Custom Security Filter
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
-    // DI 받은 AuthenticationManager는 로그인 인증 정보(Username/Password)를 전달받아 UserDetailsService와 인터랙션 한 뒤 인증 여부를 판단
-    private final JwtTokenizer jwtTokenizer;
-    // DI 받은 JwtTokenizer는 클라이언트가 인증에 성공할 경우, JWT를 생성 및 발급하는 역할
     private final TokenService tokenService;
 
-    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtTokenizer jwtTokenizer, TokenService tokenService) {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager,TokenService tokenService) {
         this.authenticationManager = authenticationManager;
-        this.jwtTokenizer = jwtTokenizer;
         this.tokenService = tokenService;
     }
 
     @SneakyThrows // 예외처리 무시
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) { // 인증을 시도하는 로직을 구현
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) { // 인증을 시도하는 로직
         ObjectMapper objectMapper = new ObjectMapper();
-        LoginDto loginDto = objectMapper.readValue(request.getInputStream(), LoginDto.class); // 역직렬화(Deserialization)
+        LoginDto loginDto = objectMapper.readValue(request.getInputStream(), LoginDto.class);
 
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword()); // Username과 Password 정보를 포함한 UsernamePasswordAuthenticationToken 생성
+                new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
 
-        return authenticationManager.authenticate(authenticationToken);  // UsernamePasswordAuthenticationToken을 AuthenticationManager에게 전달하면서 인증 처리를 위임
+        return authenticationManager.authenticate(authenticationToken);
     }
 
     // 인증에 성공할 경우 (Spring Security에서 자동으로) 호출되는 메서드
@@ -52,16 +48,14 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                                             HttpServletResponse response,
                                             FilterChain chain,
                                             Authentication authResult) throws ServletException, IOException {
-        Member member = (Member) authResult.getPrincipal();  // 인증 정보로 Member 엔티티 객체 만들기
+        Member member = (Member) authResult.getPrincipal();
 
-        String accessToken = tokenService.delegateAccessToken(member);   // Access Token 생성
-        String refreshToken = tokenService.delegateRefreshToken(member); // Refresh Token 생성
+        String accessToken = tokenService.delegateAccessToken(member);
+        String refreshToken = tokenService.delegateRefreshToken(member);
 
-        response.setHeader("Authorization", accessToken);  // 클리이언트한테 Access Token 보내주기 (이후에 클라이언트 측에서 백엔드 애플리케이션 측에 요청을 보낼 때마다 request header에 추가해서 클라이언트 측의 자격을 증명하는데 사용)
-        response.setHeader("Refresh", refreshToken);                   // 클리이언트한테 Refresh Token 보내주기
+        response.setHeader("Authorization", accessToken);
+        response.setHeader("Refresh", refreshToken);
 
-        this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);  // MemberAuthenticationSuccessHandler의 onAuthenticationSuccess() 메서드 호출
-        // 인증 성공 후에 할 동작을 설정해둔걸 불러와서 수행
-        // 인증 실패 할 경우 MemberAuthenticationFailureHandler클래스의 onAuthenticationFailure() 메서드는 코드 추가 없이도 알아서 호출된다.
+        this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);
     }
 }

--- a/server/edusync/src/main/java/com/codestates/edusync/filter/JwtVerificationFilter.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/filter/JwtVerificationFilter.java
@@ -23,57 +23,55 @@ import java.util.Map;
 
 import static com.codestates.edusync.security.auth.utils.ErrorResponder.sendErrorResponse;
 
-// JWT 검증 필터 구현 클래스
+// JWT 검증 필터
 // 클라이언트 측에서 전송된 request header에 포함된 JWT에 대해 검증 작업을 수행하는 코드
 @RequiredArgsConstructor
-public class JwtVerificationFilter extends OncePerRequestFilter {  // OncePerRequestFilter 상속받아서 request 당 단 한 번만 수행
-    private final JwtTokenizer jwtTokenizer; // JWT를 검증하고 Claims(토큰에 포함된 정보)를 얻는 데 사용
-    private final CustomAuthorityUtils authorityUtils; // JWT 검증에 성공하면 Authentication 객체에 채울 사용자의 권한을 생성하는 데 사용
+public class JwtVerificationFilter extends OncePerRequestFilter {
+    private final JwtTokenizer jwtTokenizer;
+    private final CustomAuthorityUtils authorityUtils;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            Map<String, Object> claims = verifyJws(request); // JWT 검증
-            setAuthenticationToContext(claims);              // SecurityContext에 검증된 정보 저장
-            filterChain.doFilter(request, response);         // 인증이 성공한 경우 다음 필터 호출
+            Map<String, Object> claims = verifyJws(request);
+            setAuthenticationToContext(claims);
+            filterChain.doFilter(request, response);
         } catch (SignatureException se) {
-            sendErrorResponse(response, HttpStatus.valueOf(401), "The token information is incorrect."); // 토큰 정보가 잘못되었을 경우 401 응답 반환
+            sendErrorResponse(response, HttpStatus.valueOf(401), "The token information is incorrect.");
         } catch (MalformedJwtException me){
-            sendErrorResponse(response, HttpStatus.valueOf(401), "JWT strings must contain exactly 2 period characters"); // 토큰 정보가 잘못되었을 경우 401 응답 반환
+            sendErrorResponse(response, HttpStatus.valueOf(401), "JWT strings must contain exactly 2 period characters");
         } catch (ExpiredJwtException ee) {
-            sendErrorResponse(response, HttpStatus.valueOf(401), "The token has expired."); // JWT가 만료된 경우 401 응답 반환
+            sendErrorResponse(response, HttpStatus.valueOf(401), "The token has expired.");
         } catch (Exception e) {
-//            sendErrorResponse(response, HttpStatus.valueOf(401), "The token information is incorrect.");
-            request.setAttribute("exception", e); // 토큰의 길이가 짧으면 다른 오류를 발생시켜서 주석처리 함
+            request.setAttribute("exception", e);
             filterChain.doFilter(request, response);
         }
     }
 
-    // 특정 조건에 부합하면(true이면) 해당 Filter의 동작을 수행하지 않고 다음 Filter로 건너뛰도록 해주는 메서드인 OncePerRequestFilter의 shouldNotFilter()를 오버라이드
+    // 특정 조건에 부합하면(true이면) 해당 Filter(JwtVerificationFilter)의 동작을 수행하지 않고 다음 Filter로 건너뛰도록 해주는 메서드인 OncePerRequestFilter의 shouldNotFilter()를 오버라이드
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String authorization = request.getHeader("Authorization");
+        String accessToken = request.getHeader("Authorization");
 
-        return authorization == null;  //  header의 값이 null이면 해당 Filter(토큰 검증)의 동작을 수행하지 않도록 정의
-        // JWT가 Authorization header에 포함되지 않았다면 JWT 자격증명이 필요하지 않은 리소스에 대한 요청이라고 판단하고 다음(Next) Filter로 처리를 넘기는 것
+        return accessToken == null;
     }
 
     private Map<String, Object> verifyJws(HttpServletRequest request) { // JWT를 검증하는데 사용되는 메서드
         if(!request.getHeader("Authorization").startsWith("Bearer ")) {
             throw new SignatureException("");
         }
-        String jws = request.getHeader("Authorization").replace("Bearer ", ""); // "Bearer" 부분을 제거해서 JWT(accessToken) 얻기
-        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey()); // JWT 서명(Signature)을 검증하기 위한 Secret Key 얻기
-        Map<String, Object> claims = jwtTokenizer.getClaims(jws, base64EncodedSecretKey).getBody();   // Claims를 파싱 // 여기서 오류가 발생하면 SignatureException 발생
+        String jws = request.getHeader("Authorization").replace("Bearer ", "");
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        Map<String, Object> claims = jwtTokenizer.getClaims(jws, base64EncodedSecretKey).getBody();
 
-        return claims; // Claims가 정상적으로 파싱이 되면 서명 검증에 성공한거다.
+        return claims;
     }
 
     private void setAuthenticationToContext(Map<String, Object> claims) { //  Authentication 객체를 SecurityContext에 저장하기 위한 메서드
-        String username = (String) claims.get("email");   // 파싱한 Claims에서 username 얻기
-        List<GrantedAuthority> authorities = authorityUtils.createAuthorities((List)claims.get("roles"));  //  Claims에서 권한 정보 얻기
-        Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);  // 이미 앞에서 인증된 Authentication객체를 생성하는데 비밀번호는 불필요하니까 null입력
-        SecurityContextHolder.getContext().setAuthentication(authentication); //  SecurityContext에 Authentication 객체를 저장
+        String username = (String) claims.get("email");
+        List<GrantedAuthority> authorities = authorityUtils.createAuthorities((List)claims.get("roles"));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
 }

--- a/server/edusync/src/main/java/com/codestates/edusync/handler/MemberAccessDeniedHandler.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/handler/MemberAccessDeniedHandler.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 public class MemberAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        ErrorResponder.sendErrorResponse(response, HttpStatus.FORBIDDEN, "The member does not have permission to access the requested resource."); // 클라이언트한테 응답
-        log.warn("Forbidden error happened: {}", accessDeniedException.getMessage()); // 발생한 예외 log로 남기기
+        ErrorResponder.sendErrorResponse(response, HttpStatus.FORBIDDEN, "The member does not have permission to access the requested resource.");
+        log.warn("Forbidden error happened: {}", accessDeniedException.getMessage());
     }
 }

--- a/server/edusync/src/main/java/com/codestates/edusync/handler/MemberAuthenticationEntryPoint.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/handler/MemberAuthenticationEntryPoint.java
@@ -18,14 +18,14 @@ import java.io.IOException;
 public class MemberAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override // 인증 요청이 실패했을 때 호출되는 메서드
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        Exception exception = (Exception) request.getAttribute("exception"); // 어떤 오류인지 exception에 할당 (필터에서 저장했던 request의 Attribute 중 exception)
-        ErrorResponder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "Authentication error occurred."); // 클라이언트에게 401 응답 보내기
+        Exception exception = (Exception) request.getAttribute("exception");
+        ErrorResponder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "Authentication error occurred.");
 
-        logExceptionMessage(authException, exception); // (인증 과정에서 발생한 예외 정보 or 요청 객체에서 얻어온 예외 정보) log로 남기기
+        logExceptionMessage(authException, exception);
     }
 
     private void logExceptionMessage(AuthenticationException authException, Exception exception) {
-        String message = exception != null ? exception.getMessage() : authException.getMessage(); // exception이 null이 아니면 전자, null이면 후자를 message에 할당
+        String message = exception != null ? exception.getMessage() : authException.getMessage();
         log.warn("Unauthorized error happened: {}", message);
     }
 }

--- a/server/edusync/src/main/java/com/codestates/edusync/handler/OAuth2MemberSuccessHandler.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/handler/OAuth2MemberSuccessHandler.java
@@ -81,13 +81,13 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
         Member member;
-        if (optionalMember.isEmpty()) { // 이메일이 저장되어 있지 않은 경우
-            member = saveMember(email, nickName, profileImage, provider); // Resource Owner의 정보를 DB에 저장
+        if (optionalMember.isEmpty()) {
+            member = saveMember(email, nickName, profileImage, provider);
         } else {
             member = optionalMember.get();
         }
 
-        redirect(request, response, member);  // Access Token과 Refresh Token을 생성해서 Frontend 애플리케이션에 전달하기 위해 Redirect
+        redirect(request, response, member);
     }
 
     private Member saveMember(String email, String nickname, String profileImage, Member.Provider provider) {
@@ -107,18 +107,17 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
     }
 
     private void redirect(HttpServletRequest request, HttpServletResponse response, Member member) throws IOException {
-        String accessToken = tokenService.delegateAccessToken(member);  // JWT Access Token 생성
-        String refreshToken = tokenService.delegateRefreshToken(member);  // Refresh Token 생성
+        String accessToken = tokenService.delegateAccessToken(member);
+        String refreshToken = tokenService.delegateRefreshToken(member);
 
-        response.setHeader("Authorization", accessToken);  // 클리이언트한테 Access Token 보내주기 (이후에 클라이언트 측에서 백엔드 애플리케이션 측에 요청을 보낼 때마다 request header에 추가해서 클라이언트 측의 자격을 증명하는데 사용)
-        response.setHeader("Refresh", refreshToken);                   // 클리이언트한테 Refresh Token 보내주기
+        response.setHeader("Authorization", accessToken);
+        response.setHeader("Refresh", refreshToken);
 
-        String uri = createURI(accessToken, refreshToken).toString();   // Access Token과 Refresh Token을 포함한 URL을 생성
-        getRedirectStrategy().sendRedirect(request, response, uri);   // Frontend 애플리케이션 쪽으로 리다이렉트
+        String uri = createURI(accessToken, refreshToken).toString();
+        getRedirectStrategy().sendRedirect(request, response, uri);
 
         log.info("# Authenticated successfully!");
 
-        // response 헤더 정보 로그 출력
         for (String headerName : response.getHeaderNames()) {
             log.info(headerName + ": " + response.getHeader(headerName));
         }

--- a/server/edusync/src/main/java/com/codestates/edusync/model/member/controller/MemberController.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/member/controller/MemberController.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @RestController
 @RequestMapping("/members")
-@Validated // 유효성 검사용
+@Validated
 @Slf4j
 public class MemberController {
     private final MemberService memberService;

--- a/server/edusync/src/main/java/com/codestates/edusync/model/member/entity/Member.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/member/entity/Member.java
@@ -24,28 +24,28 @@ import static javax.persistence.FetchType.*;
 @Table(name = "member")
 public class Member extends Auditable {
     @Id // 식별자 등록
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // 식별자를 자동으로 생성
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String uuid = UUID.randomUUID().toString();
     @Column(nullable = false, updatable = true, unique = true)
     private String nickName;
     @Column(nullable = false, updatable = true, unique = true)
     private String email;
-    @Column(length = 2147483647)    // fixme : 길이 제한 걸릴 경우 length = -1 이나 columnDefinition = "TEXT" 타입 고려
+    @Column(length = -1)
     private String profileImage;
     private String password;
     @Column(length = 50)
     private String grade;
 
-    public Member(Long id, String nickName, String email, String profileImage) { // 테스트코드 작성용 생성자
+    public Member(Long id, String nickName, String email, String profileImage) {
         this.id = id;
         this.nickName = nickName;
         this.email = email;
         this.profileImage = profileImage;
     }
 
-    @ElementCollection(fetch = FetchType.EAGER) // 별도의 테이블로 생성해서 저장 // 권한 여러개 설정할거면 나중에 바꾸기 (String roles 지우고 관련 메서드 체크!)
-    private List<String> roles = new ArrayList<>(); // 권한 테이블
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles = new ArrayList<>();
     private String withMe;
     private String aboutMe;
     @Enumerated(value = EnumType.STRING)

--- a/server/edusync/src/main/java/com/codestates/edusync/model/member/repository/MemberRepository.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/member/repository/MemberRepository.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-    Optional<Member> findById(Long id);
-    List<Member> findByUuidIn(List<String> uuids);
-    Optional<Member> findByNickName(String nickName);
+    Optional<Member> findByEmail(String email); // SELECT * FROM member WHERE email = ?1;
+    Optional<Member> findById(Long id); // SELECT * FROM member WHERE id = ?1;
+    List<Member> findByUuidIn(List<String> uuids); // SELECT * FROM member WHERE uuid IN (?1);
+    Optional<Member> findByNickName(String nickName); // SELECT * FROM member WHERE nickName = ?1;
 }
 

--- a/server/edusync/src/main/java/com/codestates/edusync/security/auth/jwt/JwtTokenizer.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/security/auth/jwt/JwtTokenizer.java
@@ -20,15 +20,15 @@ import java.util.Map;
 public class JwtTokenizer { // JWT(JSON Web Token)를 생성하고 검증하는 역할을 수행하는 클래스
     @Getter
     @Value("${jwt.key}")
-    private String secretKey;       // JWT 생성 및 검증 시 사용되는 Secret Key 정보
+    private String secretKey;
 
     @Getter
     @Value("${jwt.access-token-expiration-minutes}")
-    private int accessTokenExpirationMinutes;        // Access Token에 대한 만료 시간 정보
+    private int accessTokenExpirationMinutes;
 
     @Getter
     @Value("${jwt.refresh-token-expiration-minutes}")
-    private int refreshTokenExpirationMinutes;          // Refresh Token에 대한 만료 시간 정보
+    private int refreshTokenExpirationMinutes;
 
     public String encodeBase64SecretKey(String secretKey) {
         return Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
@@ -61,13 +61,13 @@ public class JwtTokenizer { // JWT(JSON Web Token)를 생성하고 검증하는 
     }
 
     public Jws<Claims> getClaims(String jws, String base64EncodedSecretKey) {
-        Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey); // base64로 인코딩된 Secret Key를 디코딩하여 Key 객체 얻기
+        Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
 
-        Jws<Claims> claims = Jwts.parserBuilder()// JwtParserBuilder 인스턴스를 생성해서  JWT 파싱에 필요한 설정을 지정
-                .setSigningKey(key) // 서명 검증에 사용할 시크릿키를 설정
-                .build() // JwtParser 객체 생성
-                .parseClaimsJws(jws); //  입력으로 받은 JWT 토큰 문자열을 파싱+key와 비교해 검증
-        return claims; // 클레임(토큰 데이터)을 포함하는 Jws<Claims> 객체를 반환
+        Jws<Claims> claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(jws);
+        return claims;
     }
 
     public void verifySignature(String jws, String base64EncodedSecretKey) {

--- a/server/edusync/src/main/java/com/codestates/edusync/security/auth/refresh/RefreshTokenRepository.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/security/auth/refresh/RefreshTokenRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-    Optional<RefreshToken> findById(String refreshToken);
+    Optional<RefreshToken> findById(String refreshToken); // SELECT * FROM refresh_token WHERE id = ?1;
 }

--- a/server/edusync/src/main/java/com/codestates/edusync/security/auth/token/TokenService.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/security/auth/token/TokenService.java
@@ -43,11 +43,6 @@ public class TokenService {
 
         String refreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodedSecretKey);
 
-        /*
-        redis 설치가 귀찮으시다면 아래 두줄 주석처리하시면 됩니다.
-        but 리프래쉬 토큰은 사용하실 수 없습니다. (엑세스 토큰은 사용 가능)
-         */
-
         RefreshToken rtk = new RefreshToken(refreshToken, member.getId());
         refreshTokenRepository.save(rtk);
 

--- a/server/edusync/src/main/java/com/codestates/edusync/security/auth/utils/CustomAuthorityUtils.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/security/auth/utils/CustomAuthorityUtils.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 @Component
 public class CustomAuthorityUtils { // 사용자 권한 부여, 확인을 위한 클래스
-    @Value("${mail.address.admin}") // yml에 정의해 둔 관리자 이메일 가져오는거
+    @Value("${mail.address.admin}")
     private String adminMailAddress;
 
     private final List<GrantedAuthority> ADMIN_ROLES = AuthorityUtils.createAuthorityList("ROLE_ADMIN", "ROLE_USER");

--- a/server/edusync/src/main/java/com/codestates/edusync/security/auth/utils/ErrorResponder.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/security/auth/utils/ErrorResponder.java
@@ -12,9 +12,9 @@ public class ErrorResponder {
     public static void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
         Gson gson = new Gson();
         ErrorResponse errorResponse = ErrorResponse.of(status, message);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE); // 응답의 컨텐츠 타입을 JSON으로 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(status.value()); // status 작성
-        response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class)); // response body 부분 작성
+        response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));
     }
 
 


### PR DESCRIPTION
1. 너무 과도한 코드설명으로 인해 오히려 코드의 가독성이 떨어질 수 있어서 주석을 줄였습니다.

2. jpa기능을 통해 자동생성 되는 쿼리문을 주석으로 명시했습니다.