### PR TITLE
[구현] 스터디 리스트 필터링 작업 BE

### DIFF
--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/controller/StudygroupController.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/controller/StudygroupController.java
@@ -123,6 +123,19 @@ public class StudygroupController {
         return ResponseEntity.ok(new MultiResponseDto<>(responseDtoList,studygroupPage));
     }
 
+    @GetMapping(STUDYGROUP_DEFAULT_URI + "s")
+    public ResponseEntity getStudygroupPage(@RequestParam("page") @Positive Integer page,
+                                            @RequestParam("size") @Positive Integer size,
+                                            @RequestParam("order") String order){
+
+        Page<Studygroup> studygroupPage = studygroupService.getWithPagingAndOrder(page-1, size, order);
+
+        List<StudygroupResponseDto.DtoList> responseDtoList =
+                studygroupMapper.StudygroupListToStudygroupResponseDtoList(studygroupPage.getContent());
+
+        return ResponseEntity.ok(new MultiResponseDto<>(responseDtoList,studygroupPage));
+    }
+
     /**
      * 스터디 삭제
      * @param studygroupId

--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/controller/StudygroupController.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/controller/StudygroupController.java
@@ -123,12 +123,13 @@ public class StudygroupController {
         return ResponseEntity.ok(new MultiResponseDto<>(responseDtoList,studygroupPage));
     }
 
-    @GetMapping(STUDYGROUP_DEFAULT_URI + "s")
+    @GetMapping(STUDYGROUP_DEFAULT_URI + "s/order")
     public ResponseEntity getStudygroupPage(@RequestParam("page") @Positive Integer page,
                                             @RequestParam("size") @Positive Integer size,
-                                            @RequestParam("order") String order){
+                                            @RequestParam("order") String order,
+                                            @RequestParam("isAscending") Boolean isAscending){
 
-        Page<Studygroup> studygroupPage = studygroupService.getWithPagingAndOrder(page-1, size, order);
+        Page<Studygroup> studygroupPage = studygroupService.getWithPagingAndOrder(page-1, size, order, isAscending);
 
         List<StudygroupResponseDto.DtoList> responseDtoList =
                 studygroupMapper.StudygroupListToStudygroupResponseDtoList(studygroupPage.getContent());

--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/service/StudygroupService.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/service/StudygroupService.java
@@ -118,26 +118,25 @@ public class StudygroupService implements StudygroupManager{
         return findStudygroup;
     }
 
-    public Page<Studygroup> getWithPagingAndOrder(Integer page, Integer size, String order) {
-        Sort sort = getSortByOrder(order);
+    public Page<Studygroup> getWithPagingAndOrder(Integer page, Integer size, String order, Boolean isAscending) {
+        Sort sort = getSortByOrder(order, isAscending);
 
         return studygroupRepository.findAll(PageRequest.of(page, size, sort));
     }
 
-    private static Sort getSortByOrder(String order) {
+    private static Sort getSortByOrder(String order, Boolean isAscending) {
         StudygroupGetOrder orderEnum = StudygroupGetOrder.valueOfOrder(order);
         String convertedVariable = orderEnum.getVariable();
 
+        // 오름차순과 내림차순 구분
         Sort sort = Sort.by(convertedVariable);
-        if( orderEnum.getMethod().equals("descending") ) {
-            sort.descending();
-        }
-        return sort;
+        if( isAscending )   return sort;
+        else                return sort.descending();
     }
 
     @Override
     public Page<Studygroup> getWithPaging(Integer page, Integer size) {
-        return getWithPagingAndOrder(page, size, "id");
+        return getWithPagingAndOrder(page, size, "기본값");
     }
 
 

--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/service/StudygroupService.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/service/StudygroupService.java
@@ -136,7 +136,7 @@ public class StudygroupService implements StudygroupManager{
 
     @Override
     public Page<Studygroup> getWithPaging(Integer page, Integer size) {
-        return getWithPagingAndOrder(page, size, "기본값");
+        return getWithPagingAndOrder(page, size, "기본값", false);
     }
 
 

--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/utils/StudygroupGetOrder.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/utils/StudygroupGetOrder.java
@@ -5,15 +5,14 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public enum StudygroupGetOrder {
-    STUDYGROUP_GET_ORDER_BY_ID("기본값", "id", "descending"),
-    STUDYGROUP_GET_ORDER_BY_MODIFIED_AT("수정순", "modifiedAt", "descending"),
-    STUDYGROUP_GET_ORDER_BY_CATEGORY("카테고리순", "searchTags.tagKey", "ascending"),
-    STUDYGROUP_GET_ORDER_BY_RECRUITED("모집순", "isRecruited", "ascending"),
+    STUDYGROUP_GET_ORDER_BY_ID("기본값", "id"),
+    STUDYGROUP_GET_ORDER_BY_MODIFIED_AT("수정순", "modifiedAt"),
+    STUDYGROUP_GET_ORDER_BY_CATEGORY("카테고리순", "searchTags.tagKey"),
+    STUDYGROUP_GET_ORDER_BY_RECRUITED("모집순", "isRecruited"),
     ;
 
     private final @Getter String order;
     private final @Getter String variable;
-    private final @Getter String method;
 
     public static StudygroupGetOrder valueOfOrder(String order) {
         for (StudygroupGetOrder sgo : StudygroupGetOrder.values()) {

--- a/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/utils/StudygroupGetOrder.java
+++ b/server/edusync/src/main/java/com/codestates/edusync/model/study/studygroup/utils/StudygroupGetOrder.java
@@ -1,0 +1,26 @@
+package com.codestates.edusync.model.study.studygroup.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum StudygroupGetOrder {
+    STUDYGROUP_GET_ORDER_BY_ID("기본값", "id", "descending"),
+    STUDYGROUP_GET_ORDER_BY_MODIFIED_AT("수정순", "modifiedAt", "descending"),
+    STUDYGROUP_GET_ORDER_BY_CATEGORY("카테고리순", "searchTags.tagKey", "ascending"),
+    STUDYGROUP_GET_ORDER_BY_RECRUITED("모집순", "isRecruited", "ascending"),
+    ;
+
+    private final @Getter String order;
+    private final @Getter String variable;
+    private final @Getter String method;
+
+    public static StudygroupGetOrder valueOfOrder(String order) {
+        for (StudygroupGetOrder sgo : StudygroupGetOrder.values()) {
+            if (sgo.order.equals(order)) {
+                return sgo;
+            }
+        }
+        throw new IllegalArgumentException("[Studygroup get] Invalid order: " + order);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- #314 
- ***엔드포인트: /studygroups/order?page=페이지&size=크기&order=정렬방법&isAscending=false***
<br>

- order=정렬방법 을 받아서 조회하는 엔드포인트 추가
- isAscending=true / false 를 입력받아서 오름차순 / 내림차순 정렬 추가
<br>

## 작업이 필요한 이유
- 스터디 리스트 조회 시, 조회해야하는 양이 많을 경우에 필터링이 필요
<br>

## 필터링 가능 목록
- 기본값
- 수정순
- 카테고리순
- 모집순
<br>